### PR TITLE
RABSW-932 Add nnf-dm resources to dwsutil's known CRDs.

### DIFF
--- a/pkg/DWSUtility.py
+++ b/pkg/DWSUtility.py
@@ -58,6 +58,8 @@ class DWSUtility:
         "nnfnodestorages.nnf.cray.hpe.com",
         "nnfstorageprofiles.nnf.cray.hpe.com",
         "nnfstorages.nnf.cray.hpe.com",
+        "rsyncnodedatamovements.dm.cray.hpe.com",
+        "rsynctemplates.dm.cray.hpe.com",
     ]
 
     HPE_CRDS = HPE_DWS_CRDS + HPE_NNF_CRDS


### PR DESCRIPTION
Add the rsyncnodedatamovements and rsynctemplates to the list of CRDs dwsutil
knows about.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>