### PR TITLE
RABSW-927: Update for new DirectiveBreakdown fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ NOTE: This approach is based on venv and always requires you to source venv/bin/
 
 
 ```
-$ git clone git@github.hpe.com:hpe/hpc-rabsw-dwsutil.git ; cd hpc-rabsw-dwsutil
+$ git clone https://github.com/NearNodeFlash/dwsutil.git ; cd dwsutil
 
 $ python3 -m venv venv
 

--- a/pkg/crd/DirectiveBreakdown.py
+++ b/pkg/crd/DirectiveBreakdown.py
@@ -39,27 +39,37 @@ class DirectiveBreakdown:
     @property
     def dw_name(self):
         """Returns the #dw name."""
-        return self._raw_breakdown['spec']['name']
+        args = self.dw.split()
+        for arg in args:
+           if arg.startswith("name"):
+              nameArg = arg.split('=')
+              return nameArg[1]
+
+        return None
 
     @property
     def dw(self):
         """Returns the #dw directive."""
-        return self._raw_breakdown['spec']['dwRecord']['dwDirective']
+        return self._raw_breakdown['spec']['directive']
 
     @property
     def server_obj(self):
         """Returns tuple with Server CR name and namespace."""
-        if 'servers' not in self._raw_breakdown['status']:
+        if 'storage' not in self._raw_breakdown['status']:
             return None
-        return [self._raw_breakdown['status']['servers']['name'],
-                self._raw_breakdown['status']['servers']['namespace']]
+        if 'reference' not in self._raw_breakdown['status']['storage']:
+            return None
+        return [self._raw_breakdown['status']['storage']['reference']['name'],
+                self._raw_breakdown['status']['storage']['reference']['namespace']]
 
     @property
     def allocationSet(self):
         """Returns a list of Allocation objects for this breakdown."""
         allocations = []
-        allocationset = self._raw_breakdown['status']['allocationSet']
-        for allocobj in allocationset:
+        if 'storage' not in self._raw_breakdown['status']:
+            return None
+        allocationsets = self._raw_breakdown['status']['storage']['allocationSets']
+        for allocobj in allocationsets:
             obj = Allocation(allocobj)
             allocations.append(obj)
         return allocations

--- a/tests/TestUtil.py
+++ b/tests/TestUtil.py
@@ -51,46 +51,103 @@ class TestUtil(object):
             "name": "mybreakdown"
         },
         "status": {
-            "allocationSet": [
-                {
-                    "allocationStrategy": "AllocatePerCompute",
-                    "constraints": {
-                        "labels": [
-                            "dws.cray.hpe.com/storage=Rabbit"
-                        ]
-                    },
-                    "label": "xfs",
-                    "minimumCapacity": 5000000000
+            "storage": {
+                "allocationSets": [
+                    {
+                        "allocationStrategy": "AllocatePerCompute",
+                        "constraints": {
+                            "labels": [
+                                "dws.cray.hpe.com/storage=Rabbit"
+                            ]
+                        },
+                        "label": "xfs",
+                        "minimumCapacity": 5000000000
+                    }
+                ],
+                "reference": {
+                    "kind": "Servers",
+                    "name": "w-0",
+                    "namespace": "default"
                 }
-            ],
-            "ready": True,
-            "servers": {
-                "name": "w-0",
-                "namespace": "default"
-            }
+            },
+            "compute": {
+                "constraints": {
+                    "location": [
+                        {
+                            "type": "physical",
+                            "reference": {
+                                "kind": "Servers",
+                                "name": "w-0",
+                                "namespace": "default"
+                            }
+                        }
+                    ]
+                }
+            },
+            "ready": True
         }
     }
 
-    BREAKDOWNNOSERVERS_JSON = {
+    BREAKDOWNNOSTORAGE_JSON = {
         "metadata": {
             "name": "mybreakdown"
         },
         "status": {
-            "allocationSet": [
-                {
-                    "allocationStrategy": "AllocatePerCompute",
-                    "constraints": {
-                        "labels": [
-                            "dws.cray.hpe.com/storage=Rabbit"
-                        ]
-                    },
-                    "label": "xfs",
-                    "minimumCapacity": 5000000000
-                }
-            ],
-            "ready": True,
+            "ready": False
         }
     }
+
+    BREAKDOWNNOREFERENCE_JSON = {
+        "metadata": {
+            "name": "mybreakdown"
+        },
+        "status": {
+            "storage": {
+                "allocationSets": [
+                    {
+                        "allocationStrategy": "AllocatePerCompute",
+                        "constraints": {
+                            "labels": [
+                                "dws.cray.hpe.com/storage=Rabbit"
+                            ]
+                        },
+                        "label": "xfs",
+                        "minimumCapacity": 5000000000
+                    }
+                ]
+            },
+            "ready": False
+        }
+    }
+
+    BREAKDOWNNOCOMPUTE_JSON = {
+        "metadata": {
+            "name": "mybreakdown"
+        },
+        "status": {
+            "storage": {
+                "allocationSets": [
+                    {
+                        "allocationStrategy": "AllocatePerCompute",
+                        "constraints": {
+                            "labels": [
+                                "dws.cray.hpe.com/storage=Rabbit"
+                            ]
+                        },
+                        "label": "xfs",
+                        "minimumCapacity": 5000000000
+                    }
+                ],
+                "reference": {
+                    "kind": "Servers",
+                    "name": "w-0",
+                    "namespace": "default"
+                }
+            },
+            "ready": True
+        }
+    }
+
 
     NNFNODE_JSON = {
         "metadata": {

--- a/tests/testCRDs.py
+++ b/tests/testCRDs.py
@@ -276,8 +276,13 @@ class TestCRDs(unittest.TestCase, TestUtil):
         self.assertEqual(server_obj[0], "w-0")
         self.assertEqual(server_obj[1], "default")
 
-    def test_directivebreakdown_field_server_obj_server_missing(self):
-        breakdown = DirectiveBreakdown(TestUtil.BREAKDOWNNOSERVERS_JSON)
+    def test_directivebreakdown_field_server_obj_storage_missing(self):
+        breakdown = DirectiveBreakdown(TestUtil.BREAKDOWNNOSTORAGE_JSON)
+        server_obj = breakdown.server_obj
+        self.assertIsNone(server_obj)
+
+    def test_directivebreakdown_field_server_obj_reference_missing(self):
+        breakdown = DirectiveBreakdown(TestUtil.BREAKDOWNNOREFERENCE_JSON)
         server_obj = breakdown.server_obj
         self.assertIsNone(server_obj)
 


### PR DESCRIPTION
The DirectiveBreakdown resource changed to separate the status section
into "compute" and "storage" fields. Some of the fields in the "spec"
were removed, and some were moved to the status section. This commit
updates dwsutil to understand the new DirectiveBreakdown layout.

Signed-off-by: Matt Richerson <mattr@cray.com>