### PR TITLE
RABSW-1002 Teach dwsutil about LustreFileSystem and MPIJob types.

### DIFF
--- a/pkg/DWSUtility.py
+++ b/pkg/DWSUtility.py
@@ -52,6 +52,7 @@ class DWSUtility:
     ]
 
     HPE_NNF_CRDS = [
+        "lustrefilesystems.cray.hpe.com",
         "nnfaccesses.nnf.cray.hpe.com",
         "nnfdatamovements.nnf.cray.hpe.com",
         "nnfnodes.nnf.cray.hpe.com",
@@ -60,6 +61,10 @@ class DWSUtility:
         "nnfstorages.nnf.cray.hpe.com",
         "rsyncnodedatamovements.dm.cray.hpe.com",
         "rsynctemplates.dm.cray.hpe.com",
+    ]
+
+    NON_HPE_CRDS = [
+        ["mpijobs.kubeflow.org", "v1"],
     ]
 
     HPE_CRDS = HPE_DWS_CRDS + HPE_NNF_CRDS
@@ -357,9 +362,16 @@ class DWSUtility:
 
     def do_resource_list(self):
         """Brief list of resources from the DWS and NNF CRDs"""
-        hpe_crds = self.HPE_CRDS.copy()
+        hpe_crds = self.HPE_CRDS.copy() + self.NON_HPE_CRDS.copy()
 
-        for crd in hpe_crds:
+        for crd_elem in hpe_crds:
+            if isinstance(crd_elem, list):
+                crd = crd_elem[0]
+                apiver = crd_elem[1]
+            else:
+                crd = crd_elem
+                apiver = "v1alpha1"
+
             try:
                 crd_obj = self.dws.get_custom_resource_definition(crd)
             except:
@@ -369,7 +381,7 @@ class DWSUtility:
             parts = crd.split('.')
             group = '.'.join(parts[1:])
             try:
-                resources = self.dws.list_cluster_custom_object(parts[0], group)
+                resources = self.dws.list_cluster_custom_object(parts[0], group, apiver)
             except:
                 continue
 

--- a/pkg/crd/Storage.py
+++ b/pkg/crd/Storage.py
@@ -66,7 +66,9 @@ class Storage:
     @property
     def computes(self):
         """Returns the Nnfnode servers list filtered for computes."""
-        return list(filter(lambda obj: obj['name'] != self.name, self.raw_storage['data']['access']['computes']))
+        # Some test environments, such as craystack-lop, may not have computes
+        # listed for every rabbit.
+        return list(filter(lambda obj: obj['name'] != self.name, self.raw_storage['data']['access'].get('computes', [])))
 
     def has_sufficient_capacity(self, requestedCapacity):
         """Returns True if Nnfnode can meet the requested capacity."""


### PR DESCRIPTION
Teach dwsutil about LustreFileSystem and MPIJob types.

Adjust the retrieval of computes to allow for the craystack-lop case where we
have fewer computes than rabbits.

Signed-off-by: Dean Roehrich <dean.roehrich@hpe.com>